### PR TITLE
Fix format string for output file names

### DIFF
--- a/navicat_marc/marc.py
+++ b/navicat_marc/marc.py
@@ -243,7 +243,7 @@ def run_marc():
     # Output name generation
     outnames = [molecule.name for molecule in molecules]
     if None in outnames:
-        format_string = f"0{min(np.floor(l / 10), 1) + 1}"
+        format_string = f"0{int(round(min(np.floor(l / 10), 1) + 1))}d"
         outnames = [f"{basename}_{idx:{format_string}}" for idx in range(l)]
 
     # Plot tsne

--- a/navicat_marc/marc.py
+++ b/navicat_marc/marc.py
@@ -243,7 +243,7 @@ def run_marc():
     # Output name generation
     outnames = [molecule.name for molecule in molecules]
     if None in outnames:
-        format_string = f"0{int(round(min(np.floor(l / 10), 1) + 1))}d"
+        format_string = f"0{max(int(np.floor(np.log10(l)) + 1), 2)}d"
         outnames = [f"{basename}_{idx:{format_string}}" for idx in range(l)]
 
     # Plot tsne


### PR DESCRIPTION
Calculation of necessary digits in format_string could result in floats and thus strings like "02.0". Formatting with zero padding should be "02d" and not "02". Additionally the logic could result in wrong numbers of digits, e.g., 02d for l=200.

Changes made:
- Correctly calculate the padding width based on the number of items using log to determine the number of digits. Uses a minimum of 2.
- Ensure the format string uses "02d" for zero-padded integers.

This fix ensures that the format string is correctly constructed and applied, providing the appropriate padding width for integers.

Please review and merge if it looks good. Thank you!